### PR TITLE
Add border radius size option

### DIFF
--- a/scss/settings/_settings.scss
+++ b/scss/settings/_settings.scss
@@ -210,6 +210,7 @@ $badge-color: foreground($badge-background);
 $badge-padding: 0.3em;
 $badge-minwidth: 2.1em;
 $badge-font-size: 0.6rem;
+$badge-border-radius-size: rem-calc(10);
 
 // 10. Breadcrumbs
 // ---------------


### PR DESCRIPTION
Add this option for people that put a large text in the badges.
From this:
![seleccion_085](https://cloud.githubusercontent.com/assets/5034215/12958642/a951355e-d000-11e5-8ef3-316dcc902548.png)
To this:
![seleccion_086](https://cloud.githubusercontent.com/assets/5034215/12958650/b2a2ffac-d000-11e5-8e4f-3e99920c88fd.png)

